### PR TITLE
Fire ready event for all instances when ready

### DIFF
--- a/src/GoogleSdk.svelte
+++ b/src/GoogleSdk.svelte
@@ -6,6 +6,8 @@
   const dispatch = createEventDispatcher()
 
   export let apiKey
+  
+  $: $mapsLoaded && dispatch('ready')
 
   onMount(() => {
     window.byGmapsReady = () => {
@@ -28,8 +30,7 @@
 
       loader(
         url,
-        () => { return $mapsLoaded },
-        () => { dispatch('ready') }
+        () => { return $mapsLoaded }
       )
     }
   })


### PR DESCRIPTION
This allows a Svelte component to use more than one GooglePlacesAutocomplete component (such as a "From" and a "To").

Fixes #4 