### PR TITLE
(Low priority:) Remove unused exports in GoogleMap.svelte

### DIFF
--- a/src/GoogleMap.svelte
+++ b/src/GoogleMap.svelte
@@ -19,9 +19,6 @@
   let mapElement
   let map
   
-  export let styleClass = ''
-  export let value = null
-  export let styles = []
   export let center = null
   export let options = {}
 


### PR DESCRIPTION
The svelte compiler recently started complaining about these unused export properties.

I tried to build this locally to test the change, but I hit some odd dependency issues that I didn't manage to resolve, so you'll want to locally confirm that this change actually works.