### PR TITLE
Expose text of selected place prediction

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -69,7 +69,7 @@
       value = place
       viewValue = formatted_address
       currentPlace = formatted_address
-      dispatch('placeChanged', { place })
+      dispatch('placeChanged', { place, selectedPrediction: search.value })
     })
 
     dispatch('ready')


### PR DESCRIPTION
This allows developers using this component to have access to the exact text of the Google Places Autocomplete prediction entry that the user chose, in case they prefer that formatting of the place name over the `formatted_address` provided by Google.