### PR TITLE
Fixes beyonk-adventures/svelte-googlemaps#17

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -44,7 +44,7 @@
 
   function blur () {
     dispatch('blur')
-    if (viewValue !== currentPlace) {
+    if (viewValue !== (currentPlace && currentPlace[viewLabel])) {
       clear()
     }
   }


### PR DESCRIPTION
This fixes logic in GooglePlacesAutocomplete so that the component does
not always clear itself on blur.